### PR TITLE
Add .gitignore for Python projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+env/
+.venv/
+venv/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Logs
+*.log


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude Python build artifacts and virtual environment folders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c053b5c74832682a6ba5175e3f375