### PR TITLE
Add simple interactive menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,15 @@ input("Log in manually, then press Enter to continue...")
 
 This README provides an overview of how to set up the environment and manually operate the crawler to retrieve XML files from the SEFAZ portal.
 
+
+## Interactive Mode
+
+A small helper script `menu.py` provides an interactive way to run the crawler.
+Run it with Python and follow the prompts to supply the date range and list of Inscricoes Estaduais:
+
+```bash
+python menu.py
+```
+
+Type `start` when prompted to launch the download process.
+

--- a/menu.py
+++ b/menu.py
@@ -1,0 +1,36 @@
+import sys
+import crawler
+
+
+def prompt_list(prompt):
+    values = input(prompt).strip()
+    if not values:
+        return []
+    return [v for v in values.split() if v]
+
+
+def main():
+    print("NF WebCrawler Interactive Mode")
+    while True:
+        start_date = input("Start date (DD/MM/YYYY) or 'q' to quit: ").strip()
+        if start_date.lower() == 'q':
+            break
+        end_date = input("End date (DD/MM/YYYY): ").strip()
+        ies = prompt_list("IE list (space separated): ")
+        download_dir = input("Download directory [downloads]: ").strip() or "downloads"
+        action = input("Type 'start' to begin or anything else to re-enter values: ").strip().lower()
+        if action == 'start':
+            sys.argv = [
+                'crawler',
+                '--start-date', start_date,
+                '--end-date', end_date,
+                '--download-dir', download_dir,
+                '--ies',
+            ] + ies
+            crawler.main()
+        else:
+            print("Re-enter the values or type 'q' to quit.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `menu.py` for interactive CLI inputs
- document running the menu in `README.md`

## Testing
- `python -m py_compile menu.py crawler.py`
- `python menu.py` (manual exit via `q`)

------
https://chatgpt.com/codex/tasks/task_e_688c0cae1b8c8326bfe672551317f89e