### PR TITLE
Interactive login prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ While the automation is running, moving the mouse over the application window
 pauses execution. After a few seconds without movement, the process resumes
 where it stopped.
 
+When manual interaction is required (for instance, to log in on the portal), a
+small dialog appears asking you to "Continuar". After completing the step,
+click the button to resume the crawler.
+
 Run the menu with Python:
 
 ```bash

--- a/crawler.py
+++ b/crawler.py
@@ -10,14 +10,22 @@ from selenium.webdriver.support import expected_conditions as EC
 import requests
 
 from pause import PauseController
+from typing import Callable, Optional
 
 
-pause_controller: PauseController | None = None
+pause_controller: Optional[PauseController] = None
+prompt_callback: Optional[Callable[[str], None]] = None
 
 
 def set_pause_controller(controller: PauseController):
     global pause_controller
     pause_controller = controller
+
+
+def set_prompt_callback(callback: Callable[[str], None]):
+    """Set a callback to display interactive prompts."""
+    global prompt_callback
+    prompt_callback = callback
 
 
 def check_pause():
@@ -40,7 +48,11 @@ def parse_args(arg_list=None):
 
 
 def wait_for_user(prompt: str = "Press Enter to continue..."):
-    input(prompt)
+    """Pause execution until the user confirms via console or GUI."""
+    if prompt_callback:
+        prompt_callback(prompt)
+    else:
+        input(prompt)
 
 
 def open_portal(driver: webdriver.Chrome):

--- a/menu.py
+++ b/menu.py
@@ -1,5 +1,5 @@
 import threading
-from tkinter import Tk, Label, Entry, Button, StringVar, messagebox
+from tkinter import Tk, Label, Entry, Button, StringVar, messagebox, Toplevel
 
 import crawler
 from pause import PauseController
@@ -30,6 +30,8 @@ class App:
         self.ies = StringVar()
         self.download_dir = StringVar(value="downloads")
 
+        crawler.set_prompt_callback(self.show_prompt)
+
         Label(root, text="Start date (DD/MM/YYYY):").pack()
         Entry(root, textvariable=self.start_date).pack()
         Label(root, text="End date (DD/MM/YYYY):").pack()
@@ -39,6 +41,21 @@ class App:
         Label(root, text="Download directory:").pack()
         Entry(root, textvariable=self.download_dir).pack()
         Button(root, text="Start", command=self.start).pack(pady=8)
+
+    def show_prompt(self, text: str):
+        """Display a modal dialog asking the user to continue."""
+        event = threading.Event()
+
+        def _show():
+            win = Toplevel(self.root)
+            win.title("NF WebCrawler")
+            Label(win, text=text, wraplength=320).pack(padx=10, pady=10)
+            Button(win, text="Continuar", command=lambda: (event.set(), win.destroy())).pack(pady=5)
+            win.transient(self.root)
+            win.grab_set()
+
+        self.root.after(0, _show)
+        event.wait()
 
     def start(self):
         ies_list = [v for v in self.ies.get().split() if v]


### PR DESCRIPTION
## Summary
- add GUI callback for manual login steps
- show "Continuar" dialog from the Tk menu
- document interactive login prompt in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c11637014832688d5595f06da49d6