### PR TITLE
Add month/year input and folder browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ This README provides an overview of how to set up the environment and manually o
 ## Interactive Mode
 
 The `menu.py` script now launches a small graphical interface similar to a Windows
-application. Fill in the dates, the space-separated list of **Inscrições Estaduais**
-and the download directory, then click **Start**.
+application. Choose the month and year, enter the space-separated list of
+**Inscrições Estaduais** and select the download directory (use the **Browse**
+button) then click **Start**.
 
 While the automation is running, moving the mouse over the application window
 pauses execution. After a few seconds without movement, the process resumes

--- a/menu.py
+++ b/menu.py
@@ -1,5 +1,14 @@
 import threading
-from tkinter import Tk, Label, Entry, Button, StringVar, messagebox, Toplevel
+from tkinter import (
+    Tk,
+    Label,
+    Entry,
+    Button,
+    StringVar,
+    messagebox,
+    Toplevel,
+    filedialog,
+)
 
 import crawler
 from pause import PauseController
@@ -20,27 +29,34 @@ class App:
     def __init__(self, root: Tk):
         self.root = root
         root.title("NF WebCrawler")
-        root.geometry("360x220")
+        root.geometry("360x250")
 
         self.controller = PauseController()
         root.bind('<Motion>', self.controller.on_motion)
 
-        self.start_date = StringVar()
-        self.end_date = StringVar()
+        self.month = StringVar()
+        self.year = StringVar()
         self.ies = StringVar()
         self.download_dir = StringVar(value="downloads")
 
         crawler.set_prompt_callback(self.show_prompt)
 
-        Label(root, text="Start date (DD/MM/YYYY):").pack()
-        Entry(root, textvariable=self.start_date).pack()
-        Label(root, text="End date (DD/MM/YYYY):").pack()
-        Entry(root, textvariable=self.end_date).pack()
+        Label(root, text="M\u00eas (MM):").pack()
+        Entry(root, textvariable=self.month).pack()
+        Label(root, text="Ano (YYYY):").pack()
+        Entry(root, textvariable=self.year).pack()
         Label(root, text="IE list (space separated):").pack()
         Entry(root, textvariable=self.ies).pack()
         Label(root, text="Download directory:").pack()
-        Entry(root, textvariable=self.download_dir).pack()
+        dir_frame = Entry(root, textvariable=self.download_dir)
+        dir_frame.pack()
+        Button(root, text="Browse", command=self.browse_dir).pack(pady=2)
         Button(root, text="Start", command=self.start).pack(pady=8)
+
+    def browse_dir(self):
+        path = filedialog.askdirectory(initialdir=self.download_dir.get())
+        if path:
+            self.download_dir.set(path)
 
     def show_prompt(self, text: str):
         """Display a modal dialog asking the user to continue."""
@@ -59,14 +75,18 @@ class App:
 
     def start(self):
         ies_list = [v for v in self.ies.get().split() if v]
-        if not (self.start_date.get() and self.end_date.get() and ies_list):
+        month = self.month.get().zfill(2)
+        year = self.year.get()
+        if not (month and year and ies_list):
             messagebox.showerror("Missing Data", "Please fill all fields.")
             return
+        start_date = f"01/{month}/{year}"
+        end_date = f"31/{month}/{year}"
         thread = threading.Thread(
             target=run_crawler,
             args=(
-                self.start_date.get(),
-                self.end_date.get(),
+                start_date,
+                end_date,
                 ies_list,
                 self.download_dir.get(),
                 self.controller,


### PR DESCRIPTION
## Summary
- tweak README interactive mode description
- update menu to accept month/year instead of full date
- add directory browser button and automatic start/end date logic

## Testing
- `python -m py_compile menu.py crawler.py pause.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c388c6c1883269ec0d9d61b0943e6