### PR TITLE
Improve window handling in navigate_to_download_page

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -115,9 +115,13 @@ def navigate_to_download_page(driver: webdriver.Chrome):
         driver.switch_to.window(driver.window_handles[-1])
     baixar_text = cfg.get("baixar_xml_link", "Baixar XML NFE")
     try:
-        WebDriverWait(driver, 20).until(
+        baixar_link = WebDriverWait(driver, 20).until(
             EC.element_to_be_clickable((By.LINK_TEXT, baixar_text))
-        ).click()
+        )
+        existing_handles = driver.window_handles[:]
+        driver.execute_script("arguments[0].click();", baixar_link)
+        if len(driver.window_handles) > len(existing_handles):
+            driver.switch_to.window(driver.window_handles[-1])
     except TimeoutException:
         print(
             "Could not locate the 'Baixar XML NFE' link. The selector may be outdated."


### PR DESCRIPTION
## Summary
- use JavaScript click for the 'Baixar XML NFE' link
- switch focus to new window if one opens after clicking

## Testing
- `python -m py_compile crawler.py menu.py pause.py`

------
https://chatgpt.com/codex/tasks/task_e_688c3d4194048326bb638d2490e05317