### PR TITLE
Update workflow note about credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ input("Log in manually, then press Enter to continue...")
 1. Open the login page: `https://portal.sefaz.go.gov.br/portalsefaz-apps/auth/login-form`.
 2. Enter your CPF and password manually and authenticate.
 3. Navigate to **"Acesso Restrito" → "Baixar XML NFE"**.
+   > **Note:** The portal may ask for your credentials again here. The crawler
+   will pause and display a **Continuar** dialog; log in and click the button to
+   resume.
 4. If asked to re-authenticate, do so manually again.
 5. Set the date filter using the drop-down menus from `01/07/2025` to `31/07/2025`.
 6. For each **Inscrição Estadual** from your list:


### PR DESCRIPTION
## Summary
- mention that the portal may request credentials again after navigating to Baixar XML NFE
- explain that the crawler waits for user confirmation via the **Continuar** dialog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688c4cff164083269fcc93049ecd8244